### PR TITLE
add copy_tags method

### DIFF
--- a/exiftool.py
+++ b/exiftool.py
@@ -325,3 +325,8 @@ class ExifTool(object):
         ``None`` if this tag was not found in the file.
         """
         return self.get_tag_batch(tag, [filename])[0]
+
+    def copy_tags(self, fromFilename, toFilename):
+        """Copy all tags from one file to another."""
+        self.execute("-overwrite_original", "-TagsFromFile", fromFilename, toFilename)
+        


### PR DESCRIPTION
This adds a small convenience method to copy any tags from one file to another. I use it for several month now and it works fine for me.
