### PR TITLE
Added option for keeping print conversion active.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 from distutils.core import setup
 
 setup(name="PyExifTool",
-      version="0.1",
+      version="0.1-bbliem",
       description="Python wrapper for exiftool",
       license="GPLv3+",
       author="Sven Marnach",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 from distutils.core import setup
 
 setup(name="PyExifTool",
-      version="0.1-bbliem",
+      version="0.2",
       description="Python wrapper for exiftool",
       license="GPLv3+",
       author="Sven Marnach",


### PR DESCRIPTION
For some tags, disabling print conversion (as was the default before)
would not make much sense. For example, if print conversion is
deactivated, the value of the Composite:LensID tag could be reported as
something like "8D 44 5C 8E 34 3C 8F 0E". It is doubtful whether this is
useful here, as we would then need to look up what this means in a table
supplied with exiftool. We would probably like the human-readable value,
which is in this case "AF-S DX Zoom-Nikkor 18-70mm f/3.5-4.5G IF-ED".

Disabling print conversion makes sense for a lot of tags (e.g., it's
nicer to get as the exposure time not the string "1/2" but the number
0.5). In such cases, even if we enable print conversion, we can disable
it for individual tags by appending a # symbol to the tag name.