### PR TITLE
Add "shell" keyword argument to ExifTool initialization

### DIFF
--- a/exiftool.py
+++ b/exiftool.py
@@ -148,14 +148,15 @@ class ExifTool(object):
        associated with a running subprocess.
     """
 
-    def __init__(self, executable_=None):
+    def __init__(self, executable_=None, shell=True):
+        self.shell = shell
         if executable_ is None:
             self.executable = executable
         else:
             self.executable = executable_
         self.running = False
 
-    def start(self, shell=True):
+    def start(self):
         """Start an ``exiftool`` process in batch mode for this instance.
 
         This method will issue a ``UserWarning`` if the subprocess is
@@ -168,7 +169,7 @@ class ExifTool(object):
             return
         with open(os.devnull, "w") as devnull:
             startupInfo = subprocess.STARTUPINFO()
-            if not shell:
+            if not self.shell:
                 # Adding enum 11 (SW_FORCEMINIMIZE in win32api speak) will
                 # keep it from throwing up a DOS shell when it launches.
                 startupInfo.dwFlags |= 11

--- a/exiftool.py
+++ b/exiftool.py
@@ -155,7 +155,7 @@ class ExifTool(object):
             self.executable = executable_
         self.running = False
 
-    def start(self):
+    def start(self, shell=True):
         """Start an ``exiftool`` process in batch mode for this instance.
 
         This method will issue a ``UserWarning`` if the subprocess is
@@ -167,11 +167,16 @@ class ExifTool(object):
             warnings.warn("ExifTool already running; doing nothing.")
             return
         with open(os.devnull, "w") as devnull:
+            startupInfo = subprocess.STARTUPINFO()
+            if not shell:
+                # Adding enum 11 (SW_FORCEMINIMIZE in win32api speak) will
+                # keep it from throwing up a DOS shell when it launches.
+                startupInfo.dwFlags |= 11
             self._process = subprocess.Popen(
                 [self.executable, "-stay_open", "True",  "-@", "-",
                  "-common_args", "-G", "-n"],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                stderr=devnull)
+                stderr=devnull, startupinfo=startupInfo)
         self.running = True
 
     def terminate(self):

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@
 from distutils.core import setup
 
 setup(name="PyExifTool",
-      version="0.1",
+      version="0.1.1.post1",
       description="Python wrapper for exiftool",
       license="GPLv3+",
       author="Sven Marnach",
       author_email="sven@marnach.net",
-      url="http://github.com/smarnach/pyexiftool",
+      url="https://github.com/blurstudio/pyexiftool/tree/shell-option",
       classifiers=[
           "Development Status :: 3 - Alpha",
           "Intended Audience :: Developers",


### PR DESCRIPTION
On Windows this will allow to run exiftool without showing the DOS shell.